### PR TITLE
use fully qualified name on deduplication map (protect against metrics different types)

### DIFF
--- a/collectors/deduplicator.go
+++ b/collectors/deduplicator.go
@@ -77,7 +77,7 @@ func NewMetricDeduplicator(logger *slog.Logger, projectID string) *MetricDedupli
 // If seen before, returns true (duplicate detected).
 // We keep the first occurrence and drop all subsequent ones.
 // This method is thread-safe.
-func (d *MetricDeduplicator) CheckAndMark(name string, labelKeys, labelValues []string, ts time.Time) bool {
+func (d *MetricDeduplicator) CheckAndMark(name string, labelKeys, labelValues []string) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -556,7 +556,7 @@ func (c *MonitoringCollector) reportTimeSeriesMetrics(
 		// Check for duplicate metrics using deduplicator
 		// Use the full Prometheus metric name (same as what will be sent to Prometheus)
 		promMetricName := prometheus.BuildFQName(namespace, utils.NormalizeMetricName(timeSeries.Resource.Type), utils.NormalizeMetricName(timeSeries.Metric.Type))
-		if c.deduplicator.CheckAndMark(promMetricName, labelKeys, labelValues, newestEndTime) {
+		if c.deduplicator.CheckAndMark(promMetricName, labelKeys, labelValues) {
 			continue // Duplicate detected and logged by deduplicator
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fewer duplicate Prometheus metrics by deduplicating using the full normalized metric name.
  * Revert behavior in error and bucket scenarios now correctly follows the updated deduplication key.

* **Improvements**
  * More consistent metric naming via normalization for better Prometheus compatibility.
  * Increased monitoring reliability as all metric types follow the same deduplication logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->